### PR TITLE
Possible issue in instructions in `proof_of_work` fixed

### DIFF
--- a/cits2006-labs/files/blockchain.py
+++ b/cits2006-labs/files/blockchain.py
@@ -79,8 +79,8 @@ class Blockchain:
     def proof_of_work(self, last_block):
         """
         Bitcoin's SHA-256 mining algorithm:
-        - Find a number p' such that hash(pp') contains leading 4 zeroes, where p is the previous p'
-        - p is the previous proof, and p' is the new proof
+        - Find a number p' such that hash(pp'h) contains leading 4 zeroes, where:
+        - p is the previous proof, and p' is the new proof, and h is the hash of the previous block
 
         :param last_block: <dict> last Block
         :return: <int>


### PR DESCRIPTION
Heya! I was doing Task 5 for Lab 2, and I think there is a slight typo in the instructions explaining the hash that we need to find - the current instructions are:
```python
 defproof_of_work(self,last_block):
  """
 Bitcoin'sSHA-256miningalgorithm:

-Findanumberp'suchthathash(pp')containsleading4zeroes,wherepisthepreviousp'
 -pisthepreviousproof,andp'isthenewproof

 :paramlast_block:<dict>lastBlock
 :return:<int>
 """
 last_proof=last_block['proof']
 last_hash=self.hash(last_block)
```
however, if we look in the validation of the proof of work

```python
 defvalid_proof(last_proof,proof,last_hash):
  """
 ValidatestheProof

 :paramlast_proof:<int>PreviousProof
 :paramproof:<int>CurrentProof
 :paramlast_hash:<str>ThehashofthePreviousBlock
 :return:<bool>Trueifcorrect,Falseifnot.
 """
 guess=f'{last_proof}{proof}{last_hash}'.encode()
 guess_hash=hashlib.sha256(guess).hexdigest()
  print(guess_hash)
  returnguess_hash[:4]=="0000"
```
We can see that in the instructions for `proof_of_work` that it asks us to find a proof such that when it is combined with the last proof, it has a set of leading 4 zeros, however, in the `valid_proof` we can see the proof is checking for a proof value when combined with the last proof, the proof itself, and the last hash (which makes more sense tbh), so I'm pretty sure its just a slight issue with the instructions in `proof_of_work`, so I have changed the instructions to be updated to
```text
  - Find a number p' such that hash(pp'h) contains leading 4 zeroes,
where:
  - p is the previous proof, and p' is the new proof, and h is the hash
of the previous block
```